### PR TITLE
Fixing the mapping template stringification

### DIFF
--- a/aws_api_gateway/github_request_mapping_template.txt
+++ b/aws_api_gateway/github_request_mapping_template.txt
@@ -1,6 +1,6 @@
 {
-    "particle_access_token": $stageVariables.particle_access_token,
+    "particle_access_token": "$stageVariables.particle_access_token",
     
     "query_string": $input.params().querystring,
-    "request_body" : $input.path('$')
+    "request_body" : "$input.path('$')"
 }


### PR DESCRIPTION
It appears that Amazon changing the parsing rules for the mapping
templates, so now both the stage variables and request_body need to be
explicitly turned into strings. _shrug_
